### PR TITLE
secret 객체로부터 ovirt master의 정보를 받도록 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY pkg/ovirt/ pkg/ovirt/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go

--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -28,7 +28,7 @@ type VirtualMachineSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of VirtualMachine. Edit virtualmachine_types.go to remove/update
+	// Template is a template field of a new VirtualMachine instance.
 	Template string `json:"template,omitempty"`
 }
 

--- a/config/crd/bases/vm.tmaxcloud.com_virtualmachines.yaml
+++ b/config/crd/bases/vm.tmaxcloud.com_virtualmachines.yaml
@@ -37,8 +37,8 @@ spec:
             description: VirtualMachineSpec defines the desired state of VirtualMachine
             properties:
               template:
-                description: Foo is an example field of VirtualMachine. Edit virtualmachine_types.go
-                  to remove/update
+                description: Template is a template field of a new VirtualMachine
+                  instance.
                 type: string
             type: object
           status:

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/ovirt/go-ovirt v4.3.4+incompatible
+	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
 	sigs.k8s.io/controller-runtime v0.7.2

--- a/pkg/ovirt/actuator.go
+++ b/pkg/ovirt/actuator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-logr/logr"
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
 	vmv1alpha1 "github.com/tmax-cloud/hypercloud-ovirt-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -24,12 +25,13 @@ type OvirtActuator struct {
 
 // NewActuator creates new OvirtActuator
 func NewActuator() *OvirtActuator {
-	return &OvirtActuator{
-		conn: nil,
-		url:  "https://node1.test.dom/ovirt-engine/api",
-		name: "admin@internal",
-		pass: "1",
-	}
+	return &OvirtActuator{}
+}
+
+func (actuator *OvirtActuator) SetActuator(secret *corev1.Secret) {
+	actuator.url = string(secret.Data["url"])
+	actuator.name = string(secret.Data["name"])
+	actuator.pass = string(secret.Data["pass"])
 }
 
 func (actuator *OvirtActuator) getConnection() (*ovirtsdk4.Connection, error) {

--- a/secret/ovirt_secret.yaml
+++ b/secret/ovirt_secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ovirt-master
+type: Opaque
+stringData:
+  url:  "https://node1.test.dom/ovirt-engine/api"
+  name: "admin@internal"
+  pass: "1"


### PR DESCRIPTION
- ovirt sdk 부분 별도 분리 추가 진행(actuator)
- 기존의 ovirt master의 url,username,password를 code에 static하게 사용하던 부분을, secret 객체로부터 ovirt master의 정보를 받도록 변경.
예)
```
apiVersion: v1
kind: Secret
metadata:
  name: ovirt-master
type: Opaque
stringData:
  url:  "https://node1.test.dom/ovirt-engine/api"
  name: "admin@internal"
  pass: "1"
```
- secret은 "default" namespace의 "ovirt-master" name으로 받도록 결정
